### PR TITLE
infinite auth refresh fixed

### DIFF
--- a/RTBackendTalk.podspec
+++ b/RTBackendTalk.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'RTBackendTalk'
-  s.version          = '0.1.15'
+  s.version          = '0.1.16'
   s.summary          = 'A library to add support for network requests over Alamofire'
 
 # This description is used to generate tags and improve search results.

--- a/RTBackendTalk/Classes/RequestService.swift
+++ b/RTBackendTalk/Classes/RequestService.swift
@@ -73,6 +73,7 @@ public class RequestService: RequestServiceProtocol {
                                 onError(response.error, response.response?.statusCode, nil)
                             }
                             self?.authorizationProvider?.sendTokenExpiredNotification()
+                            return
                         }
                         //Make token refresh
                         self?.authorizationProvider?.refreshToken(tokenRefreshed: { (_) in
@@ -155,6 +156,7 @@ public class RequestService: RequestServiceProtocol {
                                 onError(response.error, response.response?.statusCode, nil)
                             }
                             self?.authorizationProvider?.sendTokenExpiredNotification()
+                            return
                         }
                         //Make token refresh
                         self?.authorizationProvider?.refreshToken(tokenRefreshed: { (_) in
@@ -197,6 +199,7 @@ public class RequestService: RequestServiceProtocol {
                                 onError(response.error, response.response?.statusCode)
                             }
                             self?.authorizationProvider?.sendTokenExpiredNotification()
+                            return
                         }
                         //Make token refresh
                         self?.authorizationProvider?.refreshToken(tokenRefreshed: { (_) in
@@ -267,6 +270,7 @@ public class RequestService: RequestServiceProtocol {
                                                                                     onError(response.error, response.response?.statusCode, nil)
                                                                     }
                                                                     self?.authorizationProvider?.sendTokenExpiredNotification()
+                                                                                return
                                                                 }
                                                                 //Make token refresh
                                                                 self?.authorizationProvider?.refreshToken(tokenRefreshed: { (_) in
@@ -351,6 +355,7 @@ public class RequestService: RequestServiceProtocol {
                                         onError(response.error, response.response?.statusCode, nil)
                                     }
                                     self?.authorizationProvider?.sendTokenExpiredNotification()
+                                    return
                                 }
                                 //Make token refresh
                                 self?.authorizationProvider?.refreshToken(tokenRefreshed: { (_) in


### PR DESCRIPTION
@rentateam-a-25 Нашла еще один баг, из-за него при протухшем токене, если его заблаговременно не рефрешнули, отправлялись бесконечные запросы на бэк. Создаю МР, просто чтобы держать в курсе.