### PR TITLE
0.1.20 - Добавил поддержку Encodable для request в виде функции makeJsonRequestEncodable

### DIFF
--- a/RTBackendTalk/Classes/Crypto/BucketProtocol.swift
+++ b/RTBackendTalk/Classes/Crypto/BucketProtocol.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public protocol BucketProtocol: class {
+public protocol BucketProtocol: AnyObject {
     func getFileName() -> String
     func getBucketName() -> String
     func getXSecretSalt() -> String

--- a/RTBackendTalk/Classes/RequestService.swift
+++ b/RTBackendTalk/Classes/RequestService.swift
@@ -450,10 +450,30 @@ public class RequestService: RequestServiceProtocol {
         }
     }
     
+    private func getRequestUrl<T: RequestProtocolEncodable>(_ request: T) -> String {
+        if request.isAbsoluteUrl() {
+            return request.getUrl()
+        } else {
+            return self.baseUrl + request.getUrl()
+        }
+    }
+    
     private func getHeadersWithAuthTokenIfNeeded(request: RequestProtocol) -> HTTPHeaders {
+        let isAuthorizationRequired = request.isAuthorizationRequired()
+        let headers = getHeadersWithAuthTokenIfNeeded(isAuthorizationRequired: isAuthorizationRequired)
+        return headers
+    }
+    
+    private func getHeadersWithAuthTokenIfNeeded<T: RequestProtocolEncodable>(request: T) -> HTTPHeaders {
+        let isAuthorizationRequired = request.isAuthorizationRequired()
+        let headers = getHeadersWithAuthTokenIfNeeded(isAuthorizationRequired: isAuthorizationRequired)
+        return headers
+    }
+    
+    private func getHeadersWithAuthTokenIfNeeded(isAuthorizationRequired: Bool) -> HTTPHeaders {
         var headers = self.headersProvider?.getHeaders() ?? HTTPHeaders()
         
-        guard request.isAuthorizationRequired() else {
+        guard isAuthorizationRequired else {
             return headers
         }
         

--- a/RTBackendTalk/Classes/RequestService.swift
+++ b/RTBackendTalk/Classes/RequestService.swift
@@ -97,7 +97,7 @@ public class RequestService: RequestServiceProtocol {
         }
     }
     
-    public func makeJsonRequest<Foo: RequestProtocolEncodable, Bar: Decodable>(request: Foo,
+    public func makeJsonRequestEncodable<Foo: RequestProtocolEncodable, Bar: Decodable>(request: Foo,
                                                                                responseType: Bar.Type,
                                                                                onComplete: @escaping (_ response: Bar, _ statusCode: Int?) -> Void,
                                                                                onError: @escaping (_ error: Error?, _ statusCode: Int?, _ response: Bar?) -> Void,
@@ -138,7 +138,7 @@ public class RequestService: RequestServiceProtocol {
                         self?.refreshToken { [weak self] isSuccess in
                             if isSuccess {
                                 //Request again after token refresh
-                                self?.makeJsonRequest(request: request,
+                                self?.makeJsonRequestEncodable(request: request,
                                                       responseType: responseType,
                                                       onComplete: onComplete,
                                                       onError: onError,

--- a/RTBackendTalk/Classes/RequestService.swift
+++ b/RTBackendTalk/Classes/RequestService.swift
@@ -97,6 +97,73 @@ public class RequestService: RequestServiceProtocol {
         }
     }
     
+    public func makeJsonRequest<Foo: RequestProtocolEncodable, Bar: Decodable>(request: Foo,
+                                                                               responseType: Bar.Type,
+                                                                               onComplete: @escaping (_ response: Bar, _ statusCode: Int?) -> Void,
+                                                                               onError: @escaping (_ error: Error?, _ statusCode: Int?, _ response: Bar?) -> Void,
+                                                                               queue: DispatchQueue = DispatchQueue.main,
+                                                                               codingStrategy: JSONDecoder.KeyDecodingStrategy = .useDefaultKeys) {
+        self.sessionManager.request(
+            self.getRequestUrl(request),
+            method: request.getMethod(),
+            parameters: request.getParams(),
+            encoder: JSONParameterEncoder.default,
+            headers: getHeadersWithAuthTokenIfNeeded(request: request))
+            .validate()
+            .validate(contentType: ["application/json"])
+            .responseJSON(queue: self.queue) { [weak self] response in
+                self?.statusCodeProvider?.notify(statusCode: response.response?.statusCode)
+                let jsonDecoder = JSONDecoder()
+                jsonDecoder.keyDecodingStrategy = codingStrategy
+                switch response.result {
+                case .success:
+                    if let jsonData = response.data {
+                        do {
+                           let json = try jsonDecoder.decode(responseType, from: jsonData)
+                            queue.async {
+                                onComplete(json, response.response?.statusCode)
+                            }
+                        } catch let error {
+                            queue.async {
+                                onError(error, response.response?.statusCode, nil)
+                            }
+                        }
+                    } else {
+                        queue.async {
+                            onError(response.error, response.response?.statusCode, nil)
+                        }
+                    }
+                case .failure(let error):
+                    if self?.authorizationProvider?.isTokenExpired(response: response.response) ?? false {
+                        self?.refreshToken { [weak self] isSuccess in
+                            if isSuccess {
+                                //Request again after token refresh
+                                self?.makeJsonRequest(request: request,
+                                                      responseType: responseType,
+                                                      onComplete: onComplete,
+                                                      onError: onError,
+                                                      queue: queue,
+                                                      codingStrategy: codingStrategy)
+                            } else {
+                                queue.async {
+                                    onError(response.error, response.response?.statusCode, nil)
+                                }
+                            }
+                        }
+                    } else {
+                        var json: Bar?
+                        if let jsonData = response.data {
+                            json = try? jsonDecoder.decode(responseType, from: jsonData)
+                        }
+
+                        queue.async {
+                            onError(error, response.response?.statusCode, json)
+                        }
+                    }
+                }
+        }
+    }
+    
     public func makeJsonRequests<RequestId, ResponseType: Decodable>(requestInfo: [RequestId: MultipleRequestInfo<ResponseType>],
                                                                      onComplete: @escaping (_ successResults: [RequestId: MultipleResponseInfo<ResponseType>],
         _ errorResults: [RequestId: MultipleResponseErrorInfo<ResponseType>]) -> Void,

--- a/RTBackendTalk/Classes/RequestServiceProtocol.swift
+++ b/RTBackendTalk/Classes/RequestServiceProtocol.swift
@@ -8,6 +8,14 @@ public protocol RequestServiceProtocol: class {
                               onError: @escaping (_ error: Error?, _ statusCode: Int?, _ response: Foo?) -> Void,
                               queue: DispatchQueue,
                               codingStrategy: JSONDecoder.KeyDecodingStrategy) where Foo: Decodable
+    
+    func makeJsonRequest<Foo, Bar: RequestProtocolEncodable>(request: Bar,
+                                                             responseType: Foo.Type,
+                                                             onComplete: @escaping (_ response: Foo, _ statusCode: Int?) -> Void,
+                                                             onError: @escaping (_ error: Error?, _ statusCode: Int?, _ response: Foo?) -> Void,
+                                                             queue: DispatchQueue,
+                                                             codingStrategy: JSONDecoder.KeyDecodingStrategy) where Foo: Decodable
+    
     func makeJsonRequests<RequestId, ResponseType: Decodable>(
         requestInfo: [RequestId: MultipleRequestInfo<ResponseType>],
         onComplete: @escaping (_ successResults: [RequestId: MultipleResponseInfo<ResponseType>], _ errorResults: [RequestId: MultipleResponseErrorInfo<ResponseType>]) -> Void,

--- a/RTBackendTalk/Classes/RequestServiceProtocol.swift
+++ b/RTBackendTalk/Classes/RequestServiceProtocol.swift
@@ -9,7 +9,7 @@ public protocol RequestServiceProtocol: AnyObject {
                               queue: DispatchQueue,
                               codingStrategy: JSONDecoder.KeyDecodingStrategy)
     
-    func makeJsonRequest<Foo: Decodable, Bar: RequestProtocolEncodable>(request: Bar,
+    func makeJsonRequestEncodable<Foo: Decodable, Bar: RequestProtocolEncodable>(request: Bar,
                                                              responseType: Foo.Type,
                                                              onComplete: @escaping (_ response: Foo, _ statusCode: Int?) -> Void,
                                                              onError: @escaping (_ error: Error?, _ statusCode: Int?, _ response: Foo?) -> Void,

--- a/RTBackendTalk/Classes/RequestServiceProtocol.swift
+++ b/RTBackendTalk/Classes/RequestServiceProtocol.swift
@@ -1,20 +1,20 @@
 import Foundation
 import Alamofire
 
-public protocol RequestServiceProtocol: class {
-    func makeJsonRequest<Foo>(request: RequestProtocol,
+public protocol RequestServiceProtocol: AnyObject {
+    func makeJsonRequest<Foo: Decodable>(request: RequestProtocol,
                               responseType: Foo.Type,
                               onComplete: @escaping (_ response: Foo, _ statusCode: Int?) -> Void,
                               onError: @escaping (_ error: Error?, _ statusCode: Int?, _ response: Foo?) -> Void,
                               queue: DispatchQueue,
-                              codingStrategy: JSONDecoder.KeyDecodingStrategy) where Foo: Decodable
+                              codingStrategy: JSONDecoder.KeyDecodingStrategy)
     
-    func makeJsonRequest<Foo, Bar: RequestProtocolEncodable>(request: Bar,
+    func makeJsonRequest<Foo: Decodable, Bar: RequestProtocolEncodable>(request: Bar,
                                                              responseType: Foo.Type,
                                                              onComplete: @escaping (_ response: Foo, _ statusCode: Int?) -> Void,
                                                              onError: @escaping (_ error: Error?, _ statusCode: Int?, _ response: Foo?) -> Void,
                                                              queue: DispatchQueue,
-                                                             codingStrategy: JSONDecoder.KeyDecodingStrategy) where Foo: Decodable
+                                                             codingStrategy: JSONDecoder.KeyDecodingStrategy)
     
     func makeJsonRequests<RequestId, ResponseType: Decodable>(
         requestInfo: [RequestId: MultipleRequestInfo<ResponseType>],

--- a/RTBackendTalk/Classes/RequestType/RequestProtocolEncodable.swift
+++ b/RTBackendTalk/Classes/RequestType/RequestProtocolEncodable.swift
@@ -1,0 +1,13 @@
+import Foundation
+import Alamofire
+
+public protocol RequestProtocolEncodable {
+    associatedtype T: Encodable
+    
+    func getUrl() -> String
+    func isAbsoluteUrl() -> Bool
+    func getMethod() -> HTTPMethod
+    func getParams() -> T?
+    func isAuthorizationRequired() -> Bool
+}
+


### PR DESCRIPTION
Ранее в request можно было передавать параметры только с помощью типа Parameters (который является словарем [String: Any])
Теперь можно передавать параметры с помощью любого типа данных, который конформит протокол Encodable.
Это избавляет нас от необходимости в ручную заполнять Parameters в стиле:

```
    func getParams() -> Parameters? {
        var parameters = Parameters()

        var address: [String:Any] = [:]
        address["appartment"] = data.contactAddress.appartment
        address["city"] = data.contactAddress.city
        address["cityFiasId"] = data.contactAddress.cityFiasId
      
        parameters["address"] = address
        return parameters
    }
```
Теперь мы можем сделать так:

```
  func getParams() -> Address? {
        return self.address
    }
```